### PR TITLE
fix: `article.body` line break error

### DIFF
--- a/lib/realworld_web/live/article_live/index.html.heex
+++ b/lib/realworld_web/live/article_live/index.html.heex
@@ -16,7 +16,7 @@
   <div class="container page">
     <div class="row article-content">
       <div class="col-md-12">
-        <article><%= raw(@article.body) %></article>
+        <article><%= raw(@article.body |> String.replace("\n", "<br/>")) %></article>
         <ul class="tag-list">
           <%= for tag <- @article.tags do %>
             <li class="tag-default tag-pill tag-outline">


### PR DESCRIPTION
The line break `\n` is not working in webpage, use `<br/>` instead.

<img width="1229" alt="image" src="https://user-images.githubusercontent.com/17933846/221357042-eb8699e0-a2e3-4fd9-93a6-e0264b6185dd.png">
[https://demo.realworld.io/#/article/quantifying-the-microchip-wont-do-anything-we-need-to-index-the-online-SQL-hard-drive!-120863](https://demo.realworld.io/#/article/quantifying-the-microchip-wont-do-anything-we-need-to-index-the-online-SQL-hard-drive!-120863)