### PR TITLE
fix: remove wrong broadcast_type

### DIFF
--- a/lib/realworld/articles/resources/comment.ex
+++ b/lib/realworld/articles/resources/comment.ex
@@ -30,7 +30,6 @@ defmodule Realworld.Articles.Comment do
   pub_sub do
     module RealworldWeb.Endpoint
     prefix "comment"
-    broadcast_type :phoenix_broadcast
 
     publish :create, ["created", :article_id]
     publish :destroy, ["destroyed", :article_id]

--- a/lib/realworld_web/live/article_live/index.ex
+++ b/lib/realworld_web/live/article_live/index.ex
@@ -141,7 +141,7 @@ defmodule RealworldWeb.ArticleLive.Index do
 
   @impl true
   def handle_info(
-        %{topic: "comment:created:" <> _, event: "create", payload: %{payload: %{data: comment}}},
+        %{topic: "comment:created:" <> _, event: "create", payload: %{data: comment}},
         socket
       ) do
     socket =
@@ -156,7 +156,7 @@ defmodule RealworldWeb.ArticleLive.Index do
         %{
           topic: "comment:destroyed:" <> _,
           event: "destroy",
-          payload: %{payload: %{data: comment}}
+          payload: %{data: comment}
         },
         socket
       ) do


### PR DESCRIPTION
`broadcast_type :phoenix_broadcast` is unneeded (since endpoint module is used) and results in `%Broadcast{payload: %Broadcast{payload: ...}}`.