### PR TITLE
chore(articles): Use get_by in articles domain interface

### DIFF
--- a/lib/realworld/articles/article.ex
+++ b/lib/realworld/articles/article.ex
@@ -30,13 +30,6 @@ defmodule Realworld.Articles.Article do
   actions do
     defaults [:read, :destroy]
 
-    read :by_slug do
-      get? true
-      argument :slug, :string, allow_nil?: false
-
-      filter expr(slug == ^arg(:slug))
-    end
-
     read :list_articles do
       argument :filter, :map, allow_nil?: true
       argument :private_feed?, :boolean, allow_nil?: false, default: false

--- a/lib/realworld/articles/articles.ex
+++ b/lib/realworld/articles/articles.ex
@@ -7,7 +7,7 @@ defmodule Realworld.Articles do
 
   resources do
     resource Realworld.Articles.Article do
-      define :get_article_by_slug, action: :by_slug, args: [:slug]
+      define :get_article_by_slug, action: :read, get_by: :slug
       define :list_articles
       define :destroy_article, action: :destroy
     end


### PR DESCRIPTION
Using the `:read` action and `get_by: :slug` makes the Articles domain simpler and more straight-forward, it also reduces the lines of code in the article resource because we no longer need the `by_slug` action